### PR TITLE
Add Werkzeug as dependency

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,4 +1,5 @@
 ipython==7.12.0
 Flask==2.0.3
 Flask-Compress==1.3.0
+Werkzeug==2.2.2
 nl4dv


### PR DESCRIPTION
Flask 2.x is not made for Werkzeug 3, hence need to explicitly declare in requirements