### PR TITLE
Replace OpenAI with LiteLLM to support different LLM providers

### DIFF
--- a/examples/app.py
+++ b/examples/app.py
@@ -34,9 +34,11 @@ def init():
         request.form['processing_mode'] = 'semantic-parsing'
 
     processing_mode = request.form['processing_mode']
-    if processing_mode == "gpt":
-            openai_key = request.form['openAIKey']
-            nl4dv_instance = NL4DV(processing_mode="gpt", gpt_api_key=openai_key, verbose=True)
+    if processing_mode == "llm":
+            api_key = request.form['api_key']
+            api_base = request.form['api_base']
+            model = request.form['model']
+            nl4dv_instance = NL4DV(processing_mode="llm", model=model, api_key=api_key, api_base=api_base, verbose=True)
 
     elif processing_mode == "semantic-parsing":
         dependency_parser = request.form['dependency_parser']

--- a/nl4dv/utils/constants.py
+++ b/nl4dv/utils/constants.py
@@ -263,7 +263,7 @@ date_regexes = [
         # 1/24/2019
         # 07/24/2019
         # 1/24/20
-    [['%m/%d/%Y', '%m/%d/%y'], "([1][0-2]|[0]?[1-9])[-.\/]([1|2][0-9]|[3][0|1]|[0]?[1-9])[-.\/]([1-9][0-9]{3}|[0-9]{2})"],
+    [['%m/%d/%Y', '%m/%d/%y'], r"([1][0-2]|[0]?[1-9])[-.\/]([1|2][0-9]|[3][0|1]|[0]?[1-9])[-.\/]([1-9][0-9]{3}|[0-9]{2})"],
     # Format:
         # YY(YY)*MM*DD where * ∈ {. - /}
     # Examples:
@@ -274,7 +274,7 @@ date_regexes = [
         # 2019/1/24
         # 2019/07/24
         # 20/1/24
-    [['%Y/%m/%d', '%y/%m/%d'], "([1-9][0-9]{3}|[0-9]{2})[-.\/]([1][0-2]|[0]?[1-9])[-.\/]([1|2][0-9]|[3][0|1]|[0]?[1-9])"],
+    [['%Y/%m/%d', '%y/%m/%d'], r"([1-9][0-9]{3}|[0-9]{2})[-.\/]([1][0-2]|[0]?[1-9])[-.\/]([1|2][0-9]|[3][0|1]|[0]?[1-9])"],
     # Format:
         # DD*MM*YY(YY) where * ∈ {. - /}
     # Examples:
@@ -285,31 +285,31 @@ date_regexes = [
         # 24/1/2019
         # 24/07/2019
         # 24/1/20
-    [['%d/%m/%Y', '%d/%m/%y'], "([1|2][0-9]|[3][0|1]|[0]?[1-9])[-.\/]([1][0-2]|[0]?[1-9])[-.\/]([1-9][0-9]{3}|[0-9]{2})"],
+    [['%d/%m/%Y', '%d/%m/%y'], r"([1|2][0-9]|[3][0|1]|[0]?[1-9])[-.\/]([1][0-2]|[0]?[1-9])[-.\/]([1-9][0-9]{3}|[0-9]{2})"],
     # Formats:
         # DD*MMM(M)*YY(YY) where * ∈ {. - / <space>}
     # Examples:
         # 8-January-2019
         # 31 Dec 19
-    [['%d/%b/%Y', '%d/%B/%Y', '%d/%b/%y', '%d/%B/%y'], "([1|2][0-9]|[3][0|1]|[0]?[1-9])[-.\/\s](January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[-.\/\s]([1-9][0-9]{3}|[0-9]{2})"],
+    [['%d/%b/%Y', '%d/%B/%Y', '%d/%b/%y', '%d/%B/%y'], r"([1|2][0-9]|[3][0|1]|[0]?[1-9])[-.\/\s](January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[-.\/\s]([1-9][0-9]{3}|[0-9]{2})"],
     # Format:
         # DD*MMM(M) where * ∈ {. - / <space>}
     # Examples:
         # 31-January
         # 1 Jul
-    [['%d/%b', '%d/%B'], "([1|2][0-9]|[3][0|1]|[0]?[1-9])[-.\/\s](January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)"],
+    [['%d/%b', '%d/%B'], r"([1|2][0-9]|[3][0|1]|[0]?[1-9])[-.\/\s](January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)"],
     # Formats:
         # MMM(M)*DD*YYY(Y) where * ∈ {. - / <space>}
     # Examples:
         # January-8-2019
         # Dec 31 19
-    [['%b/%d/%Y', '%B/%d/%Y', '%b/%d/%y', '%B/%d/%y'], "(January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[-.\/\s]([1|2][0-9]|[3][0|1]|[0]?[1-9])[-.\/\s]([1-9][0-9]{3}|[0-9]{2})"],
+    [['%b/%d/%Y', '%B/%d/%Y', '%b/%d/%y', '%B/%d/%y'], r"(January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[-.\/\s]([1|2][0-9]|[3][0|1]|[0]?[1-9])[-.\/\s]([1-9][0-9]{3}|[0-9]{2})"],
     # Format:
         # MMM(M)*DD where * ∈ {. - / <space>}
     # Examples:
         # January-31
         # Jul 1
-    [['%b/%d', '%B/%d'], "(January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[-.\/\s]([1|2][0-9]|[3][0|1]|[0]?[1-9])"],
+    [['%b/%d', '%B/%d'], r"(January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[-.\/\s]([1|2][0-9]|[3][0|1]|[0]?[1-9])"],
     # Format:
         # YYYY
     # Examples:

--- a/notebooks/use_lm.ipynb
+++ b/notebooks/use_lm.ipynb
@@ -1,0 +1,116 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1ca7af89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nl4dv import NL4DV\n",
+    "from pathlib import Path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "2b402fa0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/home/vijay/nl4dv/examples/assets/data')"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data_dir = Path.cwd().parent / \"examples\" / \"assets\" / \"data\"\n",
+    "housing_fp = data_dir / \"housing.csv\"\n",
+    "assert housing_fp.exists(), f\"File not found: {housing_fp}\"\n",
+    "data_dir"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "00726390",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nl4dv = NL4DV(data_url=housing_fp.as_posix(), processing_mode=\"llm\", model=\"ollama/deepseek-r1:1.5b\", api_base=\"http://localhost:11434\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6eb6a003",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'attributeMap': {'price': {'name': 'price',\n",
+       "   'queryPhrase': ['average', 'calculate', 'price'],\n",
+       "   'encode': True,\n",
+       "   'metric': 'attribute_exact_match',\n",
+       "   'inferenceType': 'explicit',\n",
+       "   'isAmbiguous': False,\n",
+       "   'ambiguity': [],\n",
+       "   'followupType': {'add': None}},\n",
+       "  'home_type': {'name': 'home_type',\n",
+       "   'queryPhrase': ['different', 'home types'],\n",
+       "   'encode': True,\n",
+       "   'metric': 'attribute_exact_match',\n",
+       "   'inferenceType': 'explicit',\n",
+       "   'isAmbiguous': False,\n",
+       "   'ambiguity': [],\n",
+       "   'followupType': {'add': None}}},\n",
+       " 'taskMap': [{'task': 'calculate average',\n",
+       "   'queryPhrase': ['average', 'calculate'],\n",
+       "   'values': ['price'],\n",
+       "   'attributes': ['price'],\n",
+       "   'operator': 'IN'}],\n",
+       " 'visType': 'None',\n",
+       " 'followupType': {'add': None},\n",
+       " 'dialogId': '0',\n",
+       " 'queryId': '0'}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "resp_1 = nl4dv.analyze_query(\"Show average prices for different home types over the years\")\n",
+    "resp_1"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ si-prefix~=1.3.3
 spacy~=3.0
 vega~=3.1
 inflect~=5.5
-openai~=0.28.1
+litellm~=1.67.2
 numpy==1.26.4


### PR DESCRIPTION
### Summary
Updates to support configurable LLM backends beyond OpenAI's GPT, enabling integration with different LLM providers by using LiteLLM.

### Changes
- Replaced processing_mode="gpt" with processing_mode="llm"
- Added new parameters to support different LLM configurations:
  - api_key: Authentication key for LLM service
  - api_base: Base URL for LLM API endpoint
  - model: Model identifier (default: "gpt-4-mini")
  
#### Constructor signature update
```
def __init__(self,
             ...
             processing_mode='semantic-parsing', # Literal['llm', 'semantic-parsing']
             api_key='',
             api_base='',
             model="gpt-4-mini"):
```

### Breaking Changes
The PR introduces a breaking change in how LLM processing is configured. The `processing_mode="gpt"` is being replaced with `processing_mode="llm"`