### PR TITLE
Fix: Refactor dataset URL handling in Vega-Lite specifications

### DIFF
--- a/nl4dv/__init__.py
+++ b/nl4dv/__init__.py
@@ -366,7 +366,8 @@ class NL4DV:
         query_prompt = self.lm_query_genie_instance.prompt
 
         # Adjust the data URL in the prompt if needed
-        query_prompt = query_prompt.replace(self.data_url, "https://raw.githubusercontent.com/" + self.data_url)
+        # query_prompt = query_prompt.replace(self.data_url, "https://raw.githubusercontent.com/" + self.data_url)
+        query_prompt = re.sub(r"<INSERT DATASET URL HERE>", self.data_url, query_prompt)
 
         # Read and sample the dataset
         dataset_sample = pd.read_csv(self.data_url, index_col=False).head(10).to_string(index=False)

--- a/nl4dv/lm_querygenie/lm_querygenie.py
+++ b/nl4dv/lm_querygenie/lm_querygenie.py
@@ -166,8 +166,11 @@ class LM_QueryGenie:
         }
         ]'
 
-        If a field called **PREVIOUS ANALYTIC SPECIFICATION** appears below the natural language query, classify the below natural language query into the respective follow-up operations they map to. Utilize the previous analytic specification (including the attributeMap, taskMap, and visList) and modify this specification to reflect the changes specified and requested in the natural language query. Return the visualization type in the form of a Vega-Lite specification where it reads data from url: https://raw.githubusercontent.com/nl4dv/nl4dv/master/examples/assets/data/movies-w-year.csv.
-        However, if there is no field called PREVIOUS ANALYTIC SPECIFICATION that is below the natural language query, then using the above definitions, classify the below natural language queries into the respective analytic tasks they map to. There can be one or more analytic tasks detected in the input natural language query. Return the visualization type in the form of a Vega-Lite specification where it reads data from the url above. PLEASE ensure that the schema used in your Vega-Lite specification is https://vega.github.io/schema/vega-lite/v6.json.
+        Return the visualization type in the form of a Vega-Lite specification where it reads data from url: <INSERT DATASET URL HERE>.
+        PLEASE ensure that the schema used in your Vega-Lite specification is https://vega.github.io/schema/vega-lite/v6.json.
+
+        If a field called **PREVIOUS ANALYTIC SPECIFICATION** appears below the natural language query, classify the below natural language query into the respective follow-up operations they map to. Utilize the previous analytic specification (including the attributeMap, taskMap, and visList) and modify this specification to reflect the changes specified and requested in the natural language query.
+        However, if there is no field called PREVIOUS ANALYTIC SPECIFICATION that is below the natural language query, then using the above definitions, classify the below natural language queries into the respective analytic tasks they map to. There can be one or more analytic tasks detected in the input natural language query. Return the visualization type in the form of a Vega-Lite specification where it reads data from the url above.
 
         Here's a subset of the original dataset with actual columns and rows for reference.
 


### PR DESCRIPTION
# Fix: Refactor dataset URL handling in Vega-Lite specifications

## Summary
This PR refactors the dataset URL handling mechanism in the `analyze_query_lm` method to use a more robust placeholder-based approach instead of string replacement.

## Problem
The previous implementation used a simple string replacement approach:
```python
query_prompt = query_prompt.replace(self.data_url, "https://raw.githubusercontent.com/" + self.data_url)
```

This approach hardcoded URL transformation, always prepending `https://raw.githubusercontent.com/` regardless of the actual URL format.

## Solution
Replaced the string replacement with a regex-based placeholder substitution:
```python
query_prompt = re.sub(r"<INSERT DATASET URL HERE>", self.data_url, query_prompt)
```
When users provide a dataset URL, the system now directly uses that URL in the generated Vega-Lite specifications without any automatic transformations. This ensures that the visualization specifications contain the exact URL the user intended, making them more reliable and predictable.
**Note:** Dataset URL must be hosted on GitHub for the LLM-based mode to function.

## Files Changed
- `nl4dv/__init__.py`: Updated the `analyze_query_lm` method in the NL4DV class
- `nl4dv/lm_querygenie/lm_querygenie.py`: Updated the prompt template to use the `<INSERT DATASET URL HERE>` placeholder
